### PR TITLE
fix: clear certificate env vars to prevent invalid import on macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,6 +129,9 @@ jobs:
       - name: Build Tauri app (x86_64)
         working-directory: tauri
         env:
+          # Clear certificate env vars to prevent Tauri from attempting to import invalid certificates
+          APPLE_CERTIFICATE: ""
+          APPLE_CERTIFICATE_PASSWORD: ""
           APPLE_SIGNING_IDENTITY: "-"
         run: |
           npm run build -- --target x86_64-apple-darwin --bundles app
@@ -136,6 +139,9 @@ jobs:
       - name: Build Tauri app (aarch64)
         working-directory: tauri
         env:
+          # Clear certificate env vars to prevent Tauri from attempting to import invalid certificates
+          APPLE_CERTIFICATE: ""
+          APPLE_CERTIFICATE_PASSWORD: ""
           APPLE_SIGNING_IDENTITY: "-"
         run: |
           npm run build -- --target aarch64-apple-darwin --bundles app


### PR DESCRIPTION
## Problem
macOS build fails with:
```
security: SecKeychainItemImport: One or more parameters passed to a function were not valid.
failed to bundle project: failed to import keychain certificate
```

## Cause
Tauri bundler attempts to import keychain certificate when `APPLE_CERTIFICATE` env var exists, even if the value is empty or invalid (no secrets configured).

## Solution
Explicitly set `APPLE_CERTIFICATE` and `APPLE_CERTIFICATE_PASSWORD` to empty strings in the build steps to prevent the certificate import attempt.

This allows building unsigned macOS apps without requiring Apple Developer certificates.